### PR TITLE
Add a second method for directly equalizing heights without setting up events

### DIFF
--- a/public/class-equal-height-columns-public.php
+++ b/public/class-equal-height-columns-public.php
@@ -86,7 +86,9 @@ class Equal_Height_Columns_Public {
 
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/equal-height-columns-public.js', array( 'jquery' ), $this->version, false );
 
-		wp_localize_script( $this->plugin_name, 'equalHeightColumnElements', $this->options );
+		if ( $this->options ) {
+			wp_localize_script( $this->plugin_name, 'equalHeightColumnElements', $this->options );
+		}
 
 	}
 

--- a/public/js/equal-height-columns-public.js
+++ b/public/js/equal-height-columns-public.js
@@ -216,10 +216,15 @@
 	$.fn.equalizeTheHeights = function( minHeight, maxHeight, breakPoint ) {
 
 		// Scope our variables.
-		var tallest, e, a, width;
+		var minHeight, maxHeight, breakPoint, tallest, e, a, width;
+
+		// Make all variables optional.
+		minHeight = ( minHeight ) ? minHeight : 0;
+		maxHeight = ( maxHeight ) ? maxHeight : 0;
+		breakPoint = ( breakPoint ) ? breakPoint : 0;
 
 		// Calculate the tallest item.
-		tallest = ( minHeight ) ? minHeight : 0;
+		tallest = minHeight;
 		$( this ).each( function() {
 			$( this ).outerHeight( 'auto' );
 			if ( $( this ).outerHeight() > tallest ) {
@@ -230,7 +235,7 @@
 		// Get viewport width (taking scrollbars into account).
 		e = window;
 		a = 'inner';
-		if ( !( 'innerWidth' in window ) ) {
+		if ( ! ( 'innerWidth' in window ) ) {
 			a = 'client';
 			e = document.documentElement || document.body;
 		}

--- a/public/js/equal-height-columns-public.js
+++ b/public/js/equal-height-columns-public.js
@@ -1,5 +1,5 @@
 /**
- * Equal Heights Public JS
+ * Equal Height Columns Public JS
  *
  * @since  1.0.0
  */
@@ -40,7 +40,6 @@
 
 				// Start the party
 				$selector.initEqualHeights( null, null, breakpoint );
-
 			});
 		});
 	});
@@ -48,12 +47,11 @@
 })( jQuery );
 
 /**
- * Equal Heights Plugin
+ * Equal Heights jQuery Plugin
  *
- * Equalize the heights of elements. Great for columns or any elements
- * that need to be the same height (floats, etc).
+ * Equalize the heights of elements. Great for columns or any elements that need to be the same height.
  *
- * Based on Rob Glazebrook's (cssnewbie.com) script
+ * Based on Rob Glazebrook's (cssnewbie.com) script.
  *
  * Features
  *  - ability to include a break point (the minimum viewport width at which the script does anything)
@@ -61,18 +59,24 @@
  *  - will automatically detect new elements added to the DOM
  *  - can be called multiple times without duplicating any events
  *
- * Usage: jQuery( object ).equalHeights( [minHeight], [maxHeight], [breakPoint] );
+ * This plugin contains two methods - initEqualHeights() and equalizeTheHeights(). The initEqualHeights()
+ * method will set up all of the events to handle window resizing and manual retriggering via the global
+ * 'equalheights' event on the window. The equalizeTheHeights() method will directly equalize heights but
+ * not set up any events. Both methods work on a standard jQuery collection object and accept the same args.
  *
- * Example 1: jQuery( ".cols" ).equalHeights(); Sets all .cols to the same height.
- * Example 2: jQuery( ".cols" ).equalHeights( 400 ); Sets all .cols to at least 400px tall.
- * Example 3: jQuery( ".cols" ).equalHeights( 100, 300 ); Cols are at least 100 but no more
- * than 300 pixels tall. Elements with too much content will gain a scrollbar.
- * Example 4: jQuery( ".cols" ).equalHeights( null, null, 768 ); Only resize .cols above 768px viewport
+ * Usage for the full method: jQuery( selector ).initEqualHeights( [minHeight], [maxHeight], [breakPoint] );
+ * Usage for the direct method: jQuery( selector ).equalizeTheHeights( [minHeight], [maxHeight], [breakPoint] );
+ *
+ * Example 1: jQuery( ".cols" ).initEqualHeights(); Sets all .cols to the same height.
+ * Example 2: jQuery( ".cols" ).initEqualHeights( 400 ); Sets all .cols to at least 400px tall.
+ * Example 3: jQuery( ".cols" ).initEqualHeights( 100, 300 ); Cols are at least 100 but no more than 300 pixels
+ * tall. Elements with too much content will gain a scrollbar.
+ * Example 4: jQuery( ".cols" ).initEqualHeights( null, null, 768 ); Only resize .cols above 768px viewport
  */
 ( function( $ ) {
 	'use strict';
 
-	// Debouncing function from John Hann
+	// Debouncing function from John Hann.
 	// http://unscriptable.com/index.php/2009/03/20/debouncing-javascript-methods/
 	var debounce = function( func, threshold ) {
 
@@ -81,151 +85,140 @@
 
 		return function debounced() {
 
-			// Store the passed in function and args
+			// Store the passed in function and args.
 			var obj = this;
 			var args = arguments;
 
-			// This is the callback that the timer triggers when debouncing is complete
+			// This is the callback that the timer triggers when debouncing is complete.
 			function delayed() {
 
-				// We have successfully debounced, trigger the function
+				// We have successfully debounced, trigger the function.
 				func.apply( obj, args );
 
-				// And clear the timer
+				// And clear the timer.
 				timeout = null;
 			}
 
-			// If the timer is active, clear it
+			// If the timer is active, clear it.
 			if ( timeout ) {
 				clearTimeout( timeout );
 			}
 
-			// Set the timer to 50ms and have it call delayed() when it completes
+			// Set the timer to 50ms and have it call delayed() when it completes.
 			timeout = setTimeout( delayed, threshold || 50 );
 		};
 	};
 
-	// Main plugin function
+	// Main function for equalizing heights AND setting up events.
 	$.fn.initEqualHeights = function( minHeight, maxHeight, breakPoint ) {
 
-			// Scope our variables
-			var selector, minHeight, maxHeight, breakPoint, args, eventData,
-				ourEvents, eventSet, thisEvent, eventName;
+		// Scope our variables.
+		var selector, minHeight, maxHeight, breakPoint, args, eventData,
+			ourEvents, eventSet, thisEvent, eventName;
 
-			// Get the selector used to call equalHeights
-			selector = this.selector;
+		// Get the selector used to call equalHeights.
+		selector = this.selector;
 
-			// Use the args that were passed in or use the defaults
-			minHeight = minHeight || null;
-			maxHeight = maxHeight || null;
-			breakPoint = breakPoint || 0;
+		// Use the args that were passed in or use the defaults.
+		minHeight = minHeight || null;
+		maxHeight = maxHeight || null;
+		breakPoint = breakPoint || 0;
 
-			// Combine args into an object
-			args = { minHeight: minHeight, maxHeight: maxHeight, breakPoint: breakPoint };
+		// Combine args into an object.
+		args = { minHeight: minHeight, maxHeight: maxHeight, breakPoint: breakPoint };
 
-			// Check if our global already exists
-			if ( window.equalHeightsItems ) {
+		// Check if our global already exists.
+		if ( window.equalHeightsItems ) {
 
-				// It does, so add or overwrite the current object in it
-				window.equalHeightsItems[selector] = args;
-			} else {
+			// It does, so add or overwrite the current object in it.
+			window.equalHeightsItems[selector] = args;
+		} else {
 
-				// It doesn't, so create the global and store the current object in it
-				window.equalHeightsItems = {};
-				window.equalHeightsItems[selector] = args;
-			}
+			// It doesn't, so create the global and store the current object in it.
+			window.equalHeightsItems = {};
+			window.equalHeightsItems[selector] = args;
+		}
 
-		// Grab the current event data from the window object if it exists
+		// Grab the current event data from the window object if it exists.
 		eventData = $._data( window, 'events' ) || {};
 
-		// Store the events that will retrigger doEqualHeights()
+		// Store the events that will retrigger doEqualHeights().
 		ourEvents = [ 'resize', 'orientationchange', 'equalheights' ];
 
-		// Loop through each event and attach our handler if it isn't attached already
+		// Loop through each event and attach our handler if it isn't attached already.
 		$( ourEvents ).each( function() {
 
-			// Reset our flag to false
+			// Reset our flag to false.
 			eventSet = false;
 
-			// Store this event
+			// Store this event.
 			thisEvent = this;
 
-			// Add the namespace
+			// Add the namespace.
 			eventName = this + '.equalheights';
 
-			// Check whether this event is already on the window
+			// Check whether this event is already on the window.
 			if ( eventData[ thisEvent ] ) {
 
-				// Be careful not to disturb any unrelated listeners
+				// Be careful not to disturb any unrelated listeners.
 				$( eventData[ thisEvent ] ).each( function() {
 
-					// Confirm that the event has our namespace
+					// Confirm that the event has our namespace.
 					if ( this.namespace == 'equalheights' ) {
 
-						// It does, so set our flag to true
+						// It does, so set our flag to true.
 						eventSet = true;
 					}
 				});
 			}
 
-			// If our flag is still false then we can safely attach the event
+			// If our flag is still false then we can safely attach the event.
 			if ( ! eventSet ) {
 
-				// Namespace it and debounce it to be safe
+				// Namespace it and debounce it to be safe.
 				$( window ).on( eventName, debounce( triggerEqualHeights ) );
 			}
 		});
 
-		// Trigger the first equalizing
+		// Trigger the first equalizing.
 		triggerEqualHeights();
 	};
 
-	// Function to trigger the equalizing
+	// Function to trigger the equalizing.
 	function triggerEqualHeights() {
 
-		// Loop through each object in our global
+		// Loop through each object in our global.
 		$.each( window.equalHeightsItems, function( selector, args ) {
 
-			// Call doEqualHeights and pass in the current object
+			// Call doEqualHeights and pass in the current object.
 			doEqualHeights( selector, args );
 		});
 	}
 
-	// Function to do the equalizing of the heights
+	// Function to do the equalizing of the heights.
 	function doEqualHeights( selector, args ) {
 
-		// Scope our variables
+		// Scope our variables.
 		var $items, minHeight, maxHeight, breakPoint;
 
-		// Grab the collection of items fresh from the DOM
+		// Grab the collection of items fresh from the DOM.
 		$items = $( selector );
 
-		// Store the passed in args
+		// Store the passed in args.
 		minHeight = args.minHeight;
 		maxHeight = args.maxHeight;
 		breakPoint = args.breakPoint;
 
 		$items.equalizeTheHeights( minHeight, maxHeight, breakPoint );
-
 	}
 
-	/**
-	 * Manually/directly equalize the heights of elements in a jQuery object collection.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param int minHeight Minimum height for elements after resizing.
-	 * @param int maxHeight Maximum height for elements after resizing.
-	 * @param int breakPoint Breakpoint above which to equalize heights.
-	 *
-	 * @return jQuery collection of targeted elements.
-	 */
+	// Function for directly equalizing heights WITHOUT setting up any events.
 	$.fn.equalizeTheHeights = function( minHeight, maxHeight, breakPoint ) {
 
-		// Scope our variables
+		// Scope our variables.
 		var tallest, e, a, width;
 
-		// Calculate the tallest item
+		// Calculate the tallest item.
 		tallest = ( minHeight ) ? minHeight : 0;
 		$( this ).each( function() {
 			$( this ).outerHeight( 'auto' );
@@ -234,7 +227,7 @@
 			}
 		});
 
-		// Get viewport width (taking scrollbars into account)
+		// Get viewport width (taking scrollbars into account).
 		e = window;
 		a = 'inner';
 		if ( !( 'innerWidth' in window ) ) {
@@ -243,7 +236,7 @@
 		}
 		width = e[ a + 'Width' ];
 
-		// Equalize heights if viewport width is above the breakpoint
+		// Equalize heights if viewport width is above the breakpoint.
 		if ( width >= breakPoint ) {
 			if ( ( maxHeight ) && tallest > maxHeight ) {
 				tallest = maxHeight;
@@ -253,6 +246,5 @@
 			});
 		}
 	}
-
 
 })( jQuery );

--- a/public/js/equal-height-columns-public.js
+++ b/public/js/equal-height-columns-public.js
@@ -190,7 +190,7 @@
     function doEqualHeights( selector, args ) {
 
         // Scope our variables
-        var $items, minHeight, maxHeight, breakPoint, tallest, e, a, width;
+        var $items, minHeight, maxHeight, breakPoint;
 
         // Grab the collection of items fresh from the DOM
         $items = $( selector );
@@ -200,9 +200,29 @@
         maxHeight = args.maxHeight;
         breakPoint = args.breakPoint;
 
+        $items.equalizeTheHeights( minHeight, maxHeight, breakPoint );
+
+    }
+
+    /**
+     * Manually/directly equalize the heights of elements in a jQuery object collection.
+     *
+     * @since 1.1.0
+     *
+     * @param int minHeight Minimum height for elements after resizing.
+     * @param int maxHeight Maximum height for elements after resizing.
+     * @param int breakPoint Breakpoint above which to equalize heights.
+     *
+     * @return jQuery collection of targeted elements.
+     */
+    $.fn.equalizeTheHeights = function( minHeight, maxHeight, breakPoint ) {
+
+        // Scope our variables
+        var tallest, e, a, width;
+
         // Calculate the tallest item
         tallest = ( minHeight ) ? minHeight : 0;
-        $items.each( function() {
+        $( this ).each( function() {
             $( this ).outerHeight( 'auto' );
             if ( $( this ).outerHeight() > tallest ) {
                 tallest = $( this ).outerHeight();
@@ -223,10 +243,11 @@
             if ( ( maxHeight ) && tallest > maxHeight ) {
                 tallest = maxHeight;
             }
-            return $items.each( function() {
+            return $( this ).each( function() {
                 $( this ).outerHeight( tallest );
             });
         }
     }
+
 
 })( jQuery );

--- a/public/js/equal-height-columns-public.js
+++ b/public/js/equal-height-columns-public.js
@@ -4,41 +4,46 @@
  * @since  1.0.0
  */
 ( function( $ ) {
-    'use strict';
+	'use strict';
 
-    $( window ).on( 'load', function() {
+	$( window ).on( 'load', function() {
 
-        // Initialize equal heights using variables passed from PHP.
-        $.each( equalHeightColumnElements, function() {
+		// Don't do anything if no equal height column elements are specified.
+		if ( 'undefined' === typeof equalHeightColumnElements ) {
+			return;
+		}
 
-            // Loop through each item in the collection
-            $.each( this, function() {
+		// Initialize equal heights using variables passed from PHP.
+		$.each( equalHeightColumnElements, function() {
 
-                // Scope the vars
-                var $selector, breakpoint;
+			// Loop through each item in the collection
+			$.each( this, function() {
 
-                // Confirm that the selector is valid
-                try {
+				// Scope the vars
+				var $selector, breakpoint;
 
-                    // Test the selector
-                    $selector = $( this.selector );
+				// Confirm that the selector is valid
+				try {
 
-                } catch ( e ) {
+					// Test the selector
+					$selector = $( this.selector );
 
-                    // If we have an error, the selector must not be valid,
-                    // so skip it and continue to the next selector
-                    return true;
-                }
+				} catch ( e ) {
 
-                // Set the breakpoint
-                breakpoint = this.breakpoint;
+					// If we have an error, the selector must not be valid,
+					// so skip it and continue to the next selector
+					return true;
+				}
 
-                // Start the party
-                $selector.initEqualHeights( null, null, breakpoint );
+				// Set the breakpoint
+				breakpoint = this.breakpoint;
 
-            });
-        });
-    });
+				// Start the party
+				$selector.initEqualHeights( null, null, breakpoint );
+
+			});
+		});
+	});
 
 })( jQuery );
 
@@ -65,189 +70,189 @@
  * Example 4: jQuery( ".cols" ).equalHeights( null, null, 768 ); Only resize .cols above 768px viewport
  */
 ( function( $ ) {
-    'use strict';
+	'use strict';
 
-    // Debouncing function from John Hann
-    // http://unscriptable.com/index.php/2009/03/20/debouncing-javascript-methods/
-    var debounce = function( func, threshold ) {
+	// Debouncing function from John Hann
+	// http://unscriptable.com/index.php/2009/03/20/debouncing-javascript-methods/
+	var debounce = function( func, threshold ) {
 
-        // The timer
-        var timeout;
+		// The timer
+		var timeout;
 
-        return function debounced() {
+		return function debounced() {
 
-            // Store the passed in function and args
-            var obj = this;
-            var args = arguments;
+			// Store the passed in function and args
+			var obj = this;
+			var args = arguments;
 
-            // This is the callback that the timer triggers when debouncing is complete
-            function delayed() {
+			// This is the callback that the timer triggers when debouncing is complete
+			function delayed() {
 
-                // We have successfully debounced, trigger the function
-                func.apply( obj, args );
+				// We have successfully debounced, trigger the function
+				func.apply( obj, args );
 
-                // And clear the timer
-                timeout = null;
-            }
+				// And clear the timer
+				timeout = null;
+			}
 
-            // If the timer is active, clear it
-            if ( timeout ) {
-                clearTimeout( timeout );
-            }
+			// If the timer is active, clear it
+			if ( timeout ) {
+				clearTimeout( timeout );
+			}
 
-            // Set the timer to 50ms and have it call delayed() when it completes
-            timeout = setTimeout( delayed, threshold || 50 );
-        };
-    };
+			// Set the timer to 50ms and have it call delayed() when it completes
+			timeout = setTimeout( delayed, threshold || 50 );
+		};
+	};
 
-    // Main plugin function
-    $.fn.initEqualHeights = function( minHeight, maxHeight, breakPoint ) {
+	// Main plugin function
+	$.fn.initEqualHeights = function( minHeight, maxHeight, breakPoint ) {
 
-            // Scope our variables
-            var selector, minHeight, maxHeight, breakPoint, args, eventData,
-                ourEvents, eventSet, thisEvent, eventName;
+			// Scope our variables
+			var selector, minHeight, maxHeight, breakPoint, args, eventData,
+				ourEvents, eventSet, thisEvent, eventName;
 
-            // Get the selector used to call equalHeights
-            selector = this.selector;
+			// Get the selector used to call equalHeights
+			selector = this.selector;
 
-            // Use the args that were passed in or use the defaults
-            minHeight = minHeight || null;
-            maxHeight = maxHeight || null;
-            breakPoint = breakPoint || 0;
+			// Use the args that were passed in or use the defaults
+			minHeight = minHeight || null;
+			maxHeight = maxHeight || null;
+			breakPoint = breakPoint || 0;
 
-            // Combine args into an object
-            args = { minHeight: minHeight, maxHeight: maxHeight, breakPoint: breakPoint };
+			// Combine args into an object
+			args = { minHeight: minHeight, maxHeight: maxHeight, breakPoint: breakPoint };
 
-            // Check if our global already exists
-            if ( window.equalHeightsItems ) {
+			// Check if our global already exists
+			if ( window.equalHeightsItems ) {
 
-                // It does, so add or overwrite the current object in it
-                window.equalHeightsItems[selector] = args;
-            } else {
+				// It does, so add or overwrite the current object in it
+				window.equalHeightsItems[selector] = args;
+			} else {
 
-                // It doesn't, so create the global and store the current object in it
-                window.equalHeightsItems = {};
-                window.equalHeightsItems[selector] = args;
-            }
+				// It doesn't, so create the global and store the current object in it
+				window.equalHeightsItems = {};
+				window.equalHeightsItems[selector] = args;
+			}
 
-        // Grab the current event data from the window object if it exists
-        eventData = $._data( window, 'events' ) || {};
+		// Grab the current event data from the window object if it exists
+		eventData = $._data( window, 'events' ) || {};
 
-        // Store the events that will retrigger doEqualHeights()
-        ourEvents = [ 'resize', 'orientationchange', 'equalheights' ];
+		// Store the events that will retrigger doEqualHeights()
+		ourEvents = [ 'resize', 'orientationchange', 'equalheights' ];
 
-        // Loop through each event and attach our handler if it isn't attached already
-        $( ourEvents ).each( function() {
+		// Loop through each event and attach our handler if it isn't attached already
+		$( ourEvents ).each( function() {
 
-            // Reset our flag to false
-            eventSet = false;
+			// Reset our flag to false
+			eventSet = false;
 
-            // Store this event
-            thisEvent = this;
+			// Store this event
+			thisEvent = this;
 
-            // Add the namespace
-            eventName = this + '.equalheights';
+			// Add the namespace
+			eventName = this + '.equalheights';
 
-            // Check whether this event is already on the window
-            if ( eventData[ thisEvent ] ) {
+			// Check whether this event is already on the window
+			if ( eventData[ thisEvent ] ) {
 
-                // Be careful not to disturb any unrelated listeners
-                $( eventData[ thisEvent ] ).each( function() {
+				// Be careful not to disturb any unrelated listeners
+				$( eventData[ thisEvent ] ).each( function() {
 
-                    // Confirm that the event has our namespace
-                    if ( this.namespace == 'equalheights' ) {
+					// Confirm that the event has our namespace
+					if ( this.namespace == 'equalheights' ) {
 
-                        // It does, so set our flag to true
-                        eventSet = true;
-                    }
-                });
-            }
+						// It does, so set our flag to true
+						eventSet = true;
+					}
+				});
+			}
 
-            // If our flag is still false then we can safely attach the event
-            if ( ! eventSet ) {
+			// If our flag is still false then we can safely attach the event
+			if ( ! eventSet ) {
 
-                // Namespace it and debounce it to be safe
-                $( window ).on( eventName, debounce( triggerEqualHeights ) );
-            }
-        });
+				// Namespace it and debounce it to be safe
+				$( window ).on( eventName, debounce( triggerEqualHeights ) );
+			}
+		});
 
-        // Trigger the first equalizing
-        triggerEqualHeights();
-    };
+		// Trigger the first equalizing
+		triggerEqualHeights();
+	};
 
-    // Function to trigger the equalizing
-    function triggerEqualHeights() {
+	// Function to trigger the equalizing
+	function triggerEqualHeights() {
 
-        // Loop through each object in our global
-        $.each( window.equalHeightsItems, function( selector, args ) {
+		// Loop through each object in our global
+		$.each( window.equalHeightsItems, function( selector, args ) {
 
-            // Call doEqualHeights and pass in the current object
-            doEqualHeights( selector, args );
-        });
-    }
+			// Call doEqualHeights and pass in the current object
+			doEqualHeights( selector, args );
+		});
+	}
 
-    // Function to do the equalizing of the heights
-    function doEqualHeights( selector, args ) {
+	// Function to do the equalizing of the heights
+	function doEqualHeights( selector, args ) {
 
-        // Scope our variables
-        var $items, minHeight, maxHeight, breakPoint;
+		// Scope our variables
+		var $items, minHeight, maxHeight, breakPoint;
 
-        // Grab the collection of items fresh from the DOM
-        $items = $( selector );
+		// Grab the collection of items fresh from the DOM
+		$items = $( selector );
 
-        // Store the passed in args
-        minHeight = args.minHeight;
-        maxHeight = args.maxHeight;
-        breakPoint = args.breakPoint;
+		// Store the passed in args
+		minHeight = args.minHeight;
+		maxHeight = args.maxHeight;
+		breakPoint = args.breakPoint;
 
-        $items.equalizeTheHeights( minHeight, maxHeight, breakPoint );
+		$items.equalizeTheHeights( minHeight, maxHeight, breakPoint );
 
-    }
+	}
 
-    /**
-     * Manually/directly equalize the heights of elements in a jQuery object collection.
-     *
-     * @since 1.1.0
-     *
-     * @param int minHeight Minimum height for elements after resizing.
-     * @param int maxHeight Maximum height for elements after resizing.
-     * @param int breakPoint Breakpoint above which to equalize heights.
-     *
-     * @return jQuery collection of targeted elements.
-     */
-    $.fn.equalizeTheHeights = function( minHeight, maxHeight, breakPoint ) {
+	/**
+	 * Manually/directly equalize the heights of elements in a jQuery object collection.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int minHeight Minimum height for elements after resizing.
+	 * @param int maxHeight Maximum height for elements after resizing.
+	 * @param int breakPoint Breakpoint above which to equalize heights.
+	 *
+	 * @return jQuery collection of targeted elements.
+	 */
+	$.fn.equalizeTheHeights = function( minHeight, maxHeight, breakPoint ) {
 
-        // Scope our variables
-        var tallest, e, a, width;
+		// Scope our variables
+		var tallest, e, a, width;
 
-        // Calculate the tallest item
-        tallest = ( minHeight ) ? minHeight : 0;
-        $( this ).each( function() {
-            $( this ).outerHeight( 'auto' );
-            if ( $( this ).outerHeight() > tallest ) {
-                tallest = $( this ).outerHeight();
-            }
-        });
+		// Calculate the tallest item
+		tallest = ( minHeight ) ? minHeight : 0;
+		$( this ).each( function() {
+			$( this ).outerHeight( 'auto' );
+			if ( $( this ).outerHeight() > tallest ) {
+				tallest = $( this ).outerHeight();
+			}
+		});
 
-        // Get viewport width (taking scrollbars into account)
-        e = window;
-        a = 'inner';
-        if ( !( 'innerWidth' in window ) ) {
-            a = 'client';
-            e = document.documentElement || document.body;
-        }
-        width = e[ a + 'Width' ];
+		// Get viewport width (taking scrollbars into account)
+		e = window;
+		a = 'inner';
+		if ( !( 'innerWidth' in window ) ) {
+			a = 'client';
+			e = document.documentElement || document.body;
+		}
+		width = e[ a + 'Width' ];
 
-        // Equalize heights if viewport width is above the breakpoint
-        if ( width >= breakPoint ) {
-            if ( ( maxHeight ) && tallest > maxHeight ) {
-                tallest = maxHeight;
-            }
-            return $( this ).each( function() {
-                $( this ).outerHeight( tallest );
-            });
-        }
-    }
+		// Equalize heights if viewport width is above the breakpoint
+		if ( width >= breakPoint ) {
+			if ( ( maxHeight ) && tallest > maxHeight ) {
+				tallest = maxHeight;
+			}
+			return $( this ).each( function() {
+				$( this ).outerHeight( tallest );
+			});
+		}
+	}
 
 
 })( jQuery );

--- a/public/js/equal-height-columns-public.js
+++ b/public/js/equal-height-columns-public.js
@@ -219,9 +219,9 @@
 		var minHeight, maxHeight, breakPoint, tallest, e, a, width;
 
 		// Make all variables optional.
-		minHeight = ( minHeight ) ? minHeight : 0;
-		maxHeight = ( maxHeight ) ? maxHeight : 0;
-		breakPoint = ( breakPoint ) ? breakPoint : 0;
+		minHeight = minHeight || 0;
+		maxHeight = maxHeight || 0;
+		breakPoint = breakPoint || 0;
 
 		// Calculate the tallest item.
 		tallest = minHeight;


### PR DESCRIPTION
With these changes I think we're ready to release version 1.1.0. I've tested everything including using both the `initEqualHeights()` and `equalizeTheHeights()` methods and it's all working great. I've also updated the main block comment on the jQuery plugin to reflect the new ways to use the plugin.

We'll need at least 1 more commit to bump the version number in other plugin files after we merge these changes, then we can release 1.1.0.