### PR TITLE
Feature: Multi rows

### DIFF
--- a/public/js/equal-height-columns-public.js
+++ b/public/js/equal-height-columns-public.js
@@ -221,15 +221,16 @@
 	}
 
 	// Function for directly equalizing heights WITHOUT setting up any events.
-	$.fn.equalizeTheHeights = function( minHeight, maxHeight, breakPoint ) {
+	$.fn.equalizeTheHeights = function( minHeight, maxHeight, breakPoint, breakPointMax ) {
 
 		// Scope our variables.
-		var minHeight, maxHeight, breakPoint, tallest, e, a, width;
+		var minHeight, maxHeight, breakPoint, breakPointMax, tallest, e, a, width;
 
 		// Make all variables optional.
 		minHeight = minHeight || 0;
 		maxHeight = maxHeight || 0;
 		breakPoint = breakPoint || 0;
+		breakPointMax = breakPointMax || Number.MAX_SAFE_INTEGER;
 
 		// Calculate the tallest item.
 		tallest = minHeight;
@@ -249,8 +250,8 @@
 		}
 		width = e[ a + 'Width' ];
 
-		// Equalize heights if viewport width is above the breakpoint.
-		if ( width >= breakPoint ) {
+		// Equalize heights if viewport width is above the breakpoint and below the max-breakpoint.
+		if ( width >= breakPoint && width <= breakPointMax ) {
 			if ( ( maxHeight ) && tallest > maxHeight ) {
 				tallest = maxHeight;
 			}
@@ -260,4 +261,26 @@
 		}
 	}
 
+	$.fn.equalHeight = function( selector, columns, min, max ) {
+		selector = selector || '';
+		columns = columns || 0;
+		min = min || 0;
+		max = max || Number.MAX_SAFE_INTEGER;
+
+		$( window ).on( 'resize orientationchange equalheights', debounce( function() {
+			let width = $( window ).width();
+			if ( width >= min && width <= max ) {
+				let start;
+				let end;
+				let $elements = $( selector );
+
+				for ( start = 0, end = columns; end <= $elements.size(); start = end, end = end + columns ) {
+					$elements.slice( start, end ).equalizeTheHeights();
+				}
+				$elements.slice( start, end ).equalizeTheHeights();
+			}
+		} ) );
+
+		$( window ).trigger( 'equalheights' );
+	}
 })( jQuery );

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 **Donate link:**       http://mightyminnow.com  
 **Tags:**              equal, height, column, div, element, jQuery, JavaScript  
 **Requires at least:** 3.5  
-**Tested up to:**      6.3.1
+**Tested up to:**      6.4.1
 **Stable tag:**        1.1.4  
 **License:**           GPLv2 or later  
 **License URI:**       http://www.gnu.org/licenses/gpl-2.0.html  

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: MIGHTYminnow, Braad, McGuive7
 Donate link: http://mightyminnow.com
 Tags: equal, height, column, div, element, jQuery, JavaScript
 Requires at least: 3.5
-Tested up to: 6.3.1
+Tested up to: 6.4.1
 Stable tag: 1.1.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
This resolves a common issue where you set equal height for a group of elements, but the row of certain elements varies across breakpoints when the number of columns changes.

For example, if we have 2 columns for tablets and 3 columns for desktops, the third element in the group would be positioned on the second row for tablets but on the first row for desktops.

Before this new feature, the equal height would be based on all the elements from the group, making it look bad. Now you can have something like "subgroups" for each row, and recalculate when the rows change.

_* Currently, this solution is only available to use via JavaScript._