### PR TITLE
Address Deprecated: Function screen_icon is deprecated

### DIFF
--- a/admin/class-equal-height-columns-admin.php
+++ b/admin/class-equal-height-columns-admin.php
@@ -125,7 +125,6 @@ class Equal_Height_Columns_Admin {
 	public function output_options_page() {
 		?>
 		<div class="wrap mm-settings">
-            <?php screen_icon(); ?>
             <h2><?php echo $this->plugin_display_name; ?></h2>
             <div id="poststuff">
                 <div id="post-body" class="columns-2">

--- a/equal-height-columns.php
+++ b/equal-height-columns.php
@@ -9,7 +9,7 @@
  * @wordpress-plugin
  * Plugin Name:       Equal Height Columns
  * Description:       Apply equal heights to uneven columns and elements.
- * Version:           1.2.1
+ * Version:           1.2.2
  * Author:            MIGHTYminnow, Mickey Kay, Braad Martin
  * Author URI:        http://mightyminnow.com
  * License:           GPL-2.0+

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Tags:**              equal, height, column, div, element, jQuery, JavaScript  
 **Requires at least:** 3.5  
 **Tested up to:**      6.7.1
-**Stable tag:**        1.2.1  
+**Stable tag:**        1.2.2  
 **License:**           GPLv2 or later  
 **License URI:**       http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -155,6 +155,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 1. Activate Equal Height Columns through the 'Plugins' menu in WordPress.
 
 ## Changelog ##
+
+### 1.2.2 ###
+* BUGFIX: Deprecated: Function screen_icon is deprecated
 
 ### 1.2.1 ###
 * BUGFIX: Manual call to .initEqualHeights() was not working with recent jQuery versions.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://mightyminnow.com
 Tags: equal, height, column, div, element, jQuery, JavaScript
 Requires at least: 3.5
 Tested up to: 6.7.1
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -155,6 +155,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 1. Activate Equal Height Columns through the 'Plugins' menu in WordPress.
 
 == Changelog ==
+
+### 1.2.2 ###
+* BUGFIX: Deprecated: Function screen_icon is deprecated
 
 ### 1.2.1 ###
 * BUGFIX: Manual call to .initEqualHeights() was not working with recent jQuery versions.


### PR DESCRIPTION
See https://github.com/MIGHTYminnow/equal-height-columns/issues/8